### PR TITLE
Safety: Prefer Top-Most Intermediate Cert

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -15,8 +15,9 @@ This resource will be created with the following arguments:
  - [`client_id_list`][arg-client-id] will be set to a list containing `sts.amazonaws.com`, which is the default host for
    AWS' **S**ecurity **T**oken **S**ervice.
  - [`tags`][arg-tags] will be set to the value of `var.tags`.
- - [`thumbprint_list`][arg-thumbprint-list] will be set to a single-entry list containing the SHA-1 TLS certificate
-   fingerprint for `token.actions.githubusercontent.com`, which is detected dynamically.
+ - [`thumbprint_list`][arg-thumbprint-list]: if `var.thumbprint_list` is set, these values will be used; otherwise
+   the top-most intermediate CA certificate for `token.actions.githubusercontent.com` will be detected by Terraform
+   dynamically.
 
 These arguments can be reconfigured using [module variables](/docs/VARIABLES.md).
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -29,10 +29,13 @@ A set of thumbprints by which to verify OIDC access attempts.
 
 By default, this variable is set to an empty set, and when this is the case, this will be detected at runtime using the
 [`tls` provider's][tls-provider] [`tls_certificate`][tf-tls-certificate] data provider, grabbing the SHA-1 fingerprint
-of the server running at `url`.
+of the top-most intermediate CA certificate located at `url`.
 
 Changing this to any other value will use the user-specified values. This is entirely untested, and if you aren't using
 GitHub Enterprise, you shouldn't change/set this variable.
+
+See the AWS documentation on this topic:
+- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
 
 > **Default**: `[]` (empty set)
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,10 @@
 # github-oidc-iam Module
 
 locals {
-  # the sha-1 fingerprint for the final certificate in the chain for the server at var.url
-  github_oidc_fingerprint = data.tls_certificate.github_actions.certificates[0].sha1_fingerprint
+  github_oidc_fingerprint = data.tls_certificate.github_actions.certificates[local.certificate_chain_index].sha1_fingerprint
+
+  # as per AWS docs, choose the top-most _intermediate_ certificate if possible, otherwise choose the root certificate
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+  certificate_chain_count = length(data.tls_certificate.github_actions.certificates)
+  certificate_chain_index = local.certificate_chain_count >= 3 ? 1 : 0
 }

--- a/r.iam.tf
+++ b/r.iam.tf
@@ -3,6 +3,7 @@
 resource aws_iam_openid_connect_provider default {
   url = var.url
   client_id_list = var.sts_endpoints
+  # use the provided thumbprint list if present, otherwise use the detected one, see main.tf
   thumbprint_list = length(var.thumbprint_list) == 0 ? [local.github_oidc_fingerprint] : var.thumbprint_list
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,11 +27,14 @@ variable thumbprint_list {
     A set of thumbprints by which to verify OIDC access attempts.
 
     By default, this variable is set to an empty set, and when this is the case, this will be detected at runtime using
-    the `tls` provider's `tls_certificate` data provider, grabbing the SHA-1 fingerprint of the server running at
-    `url`.
+    the `tls` provider's `tls_certificate` data provider, grabbing the SHA-1 fingerprint of the top-most intermediate CA
+    certificate located at `url`.
 
     Changing this to any other value will use the user-specified values. This is entirely untested, and if you aren't
     using GitHub Enterprise, you shouldn't change/set this variable.
+
+    See the AWS documentation on this topic:
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
   EOF
 }
 


### PR DESCRIPTION
According to [the AWS documentation on this topic](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html), the OpenID connect provider's `thumbprint_list` should contain the SHA-1 fingerprint of the **top-most intermediate certificate** in the certificate chain:

> When you create an OpenID Connect (OIDC) identity provider in IAM, IAM requires the thumbprint **for the top intermediate certificate authority (CA)** that signed the certificate used by the external identity provider (IdP). The thumbprint is a signature for the CA's certificate that was used to issue the certificate for the OIDC-compatible IdP. When you create an IAM OIDC identity provider, you are trusting identities authenticated by that IdP to have access to your AWS account. By using the CA's certificate thumbprint, you trust any certificate issued by that CA with the same DNS name as the one registered. This eliminates the need to update trusts in each account when you renew the IdP's signing certificate.

Before this change, we used the root CA certificate as is shown in the Terraform AWS provider docs. There's probably no security impact as validation occurs as a combination of the TLS certificate thumbprint _and_ the DNS name of the service, but we are making this change to accord better with what the AWS docs specify.